### PR TITLE
Do not try to play tracks that do not have preview_url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <tbody>
               <tr>
                 <td class="tl-play">
-                  <button data-bind="css: {'spoticon-play-16': !isPlaying(), 'spoticon-spotify-connect-16': isPlaying()}, click: $parent.playTrackWithoutGap" class="astext"></button>
+                  <button data-bind="css: {'spoticon-play-16': !isPlaying() && hasPreviewTrack(), 'spoticon-spotify-connect-16': isPlaying()}, click: $parent.playTrackWithoutGap" class="astext"></button>
                 </td>
                 <td class="tl-save">
                   <button type="button" data-bind="css: {'spoticon-plus-16': !isSaved(), 'spoticon-check-16': isSaved()}, click: $parent.saveTrack", class="astext"></button>


### PR DESCRIPTION
1) When artist is selected, iterate the top tracks until one is found that has a preview_url
2) When hovering on track text, only attempt to play the track if the preview_url is provided
3) Do not display the play icon if the track does not have the preview_url

A track without a preview_url will not be removed from the UI since there is still playlist functionality and spotify links that work.

Refactoring:
- extracted the core behavior of playTrackWithoutGap and playTrack into a single function playTrackIfItHasPreview