### PR TITLE
Added back support for genres to the app

### DIFF
--- a/css/spoticons.css
+++ b/css/spoticons.css
@@ -747,6 +747,10 @@
   content: "\f18C";
   font-size: 32px;
 }
+.spoticon-spotify-icon-16:before {
+  content: "\f298";
+  font-size: 16px;
+}
 .spoticon-playlist-16:before {
   content: "\f134";
   font-size: 16px;

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
                   <button type="button" data-bind="css: {'spoticon-plus-16': !isSaved(), 'spoticon-check-16': isSaved()}, click: $parent.saveTrack", class="astext"></button>
                 </td>
                 <td class="wrapp" data-bind="event: { mouseover: $parent.playTrack, mouseout: $parent.playTrackCancel }">
-                  <a target="_blank" data-bind="text: name, attr: { href:spotifyLink }"> </a>
+                  <a target="_blank" data-bind="text: name, attr: { href:spotifyLink }"></a>
                 </td>
               </tr>
             </tbody>
@@ -108,6 +108,7 @@
             <ul data-bind="foreach: genres" id="mainGenres">
               <li>
                 <a data-bind="text: titleCaseName, click: $parent.switchToGenre"></a>
+                <a target="_blank" data-bind="attr: { href:spotifyLink }" class="spoticon-spotify-icon-16"></a>
               </li>
             </ul>
           </div>

--- a/js/main.js
+++ b/js/main.js
@@ -289,7 +289,14 @@
 
         artistInfoModel.isArtistInfoVisible(true);
         artistInfoModel.artistName(artist.name);
-        artistInfoModel.spotifyLink(artist.external_urls.spotify)
+        artistInfoModel.spotifyLink(artist.external_urls.spotify);
+        artistInfoModel.genres.removeAll();
+        artist.genres.forEach(function (genreName) {
+            artistInfoModel.genres.push({
+                titleCaseName: genreName,
+                spotifyLink: 'https://open.spotify.com/search/results/' + genreName
+            });
+        });
 
         drawChart(artist.popularity);
 
@@ -346,6 +353,9 @@
                         }
                     });
                 });
+                if(idsToRequest.length === 0){
+                    return;
+                }
                 return currentApi.getArtists(idsToRequest).then(function (data) {
                     //Sort in popularity order
                     resolve(data.artists.sort(function (a, b) {

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.10.1
 Flask-Cors==1.9.0
 pyen==2.3
 redis==2.10.3
-spotipy==2.3.3
+spotipy==2.4.4

--- a/server/server.py
+++ b/server/server.py
@@ -53,7 +53,7 @@ def cached(timeout=5 * 60, key='view/%s'):
 @app.route('/api/genres/<genre_name>/artists')
 @cached(timeout=30 * 60)
 def get_genre_artists(genre_name):
-    response = sp.recommendations(seed_genres=genre_name, limit=50)
+    response = sp.recommendations(seed_genres=[genre_name], limit=50)
     return jsonify(response)
 
 @app.route('/api/genres')


### PR DESCRIPTION
I reused the list template for an artist genres below the popularity widget.

Each genre list item now has two links.
1) The link which selects the genre within the app and loads related artists
2) A new link which is a spotify icon which will opens up spotify web app with the genre as a search term

Additional work
Spotipy needed to be upgraded a minor version to expose the recommendations method ( see requirements.txt )